### PR TITLE
Add explicit importPaths

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,5 +4,6 @@
     "authors": ["John Colvin"],
     "license": "BSL-1.0",
     "sourcePaths": ["."],
+    "importPaths": ["."],
     "targetType": "sourceLibrary",
 }


### PR DESCRIPTION
dub implicitly know that `importPaths` contains `"."` but it doesn't show up in dub describe, which prevents reggae from knowing anything about it.