### PR TITLE
Delete pyd from dependencies (problems building on Windows)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,8 +5,5 @@
     "license": "BSL-1.0",
     "sourcePaths": ["."],
     "importPaths": ["."],
-    "targetType": "sourceLibrary",
-    "dependencies": {
-        "pyd": ">=0.9.3"
-    }
+    "targetType": "sourceLibrary"
 }


### PR DESCRIPTION
I couldn't select the subConfiguration and, worse, listing pyd as an explicit dependency failed miserably.